### PR TITLE
Support Python 3.7 and run tests on multiple versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14.0-rc.1]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14.0-rc.1"]
 
     runs-on: ${{ matrix.python-version == 3.7 && 'ubuntu-22.04' || 'ubuntu-latest' }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,19 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version-file: "pyproject.toml"
+          python-version-file: ${{ matrix.python-version }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version-file: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14.0-rc.1]
 
+    runs-on: ${{ matrix.python-version == 3.7 && 'ubuntu-22.04' || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14.0-rc.1"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "~3.14.0-0"]
 
     runs-on: ${{ matrix.python-version == 3.7 && 'ubuntu-22.04' || 'ubuntu-latest' }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "timsu92",email = "33785401+timsu92@users.noreply.github.com"}
 ]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.7"
 license-files = ["LICENSE"]
 dependencies = [
     "readerwriterlock>=1.0.9",
@@ -17,3 +17,8 @@ dependencies = [
 [build-system]
 requires = ["uv_build>=0.8.3,<0.9.0"]
 build-backend = "uv_build"
+
+[dependency-groups]
+dev = [
+    "vermin>=1.6.0",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,18 @@ sortedcontainers==2.4.0 \
     --hash=sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88 \
     --hash=sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
     # via realtime-pipeline
-typing-extensions==4.14.1 \
+typing-extensions==4.7.1 ; python_full_version < '3.8' \
+    --hash=sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36 \
+    --hash=sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2
+    # via readerwriterlock
+typing-extensions==4.13.2 ; python_full_version == '3.8.*' \
+    --hash=sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c \
+    --hash=sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef
+    # via readerwriterlock
+typing-extensions==4.14.1 ; python_full_version >= '3.9' \
     --hash=sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36 \
     --hash=sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76
     # via readerwriterlock
+vermin==1.6.0 \
+    --hash=sha256:6266ca02f55d1c2aa189a610017c132eb2d1934f09e72a955b1eb3820ee6d4ef \
+    --hash=sha256:f1fa9ee40f59983dc40e0477eb2b1fa8061a3df4c3b2bcf349add462a5610efb

--- a/src/realtime_pipeline/realtime_pipeline.py
+++ b/src/realtime_pipeline/realtime_pipeline.py
@@ -1,14 +1,16 @@
 from bisect import bisect_left
 import threading
-from typing import Callable, Optional, Dict, List, Tuple
+from typing import Callable, Generic, Optional, Dict, List, Tuple, TypeVar
 
 from sortedcontainers import SortedDict
 from readerwriterlock import rwlock
 
 Timestamp = float
 
+Data = TypeVar("Data")
 
-class Node[Data](threading.Thread):
+
+class Node(Generic[Data], threading.Thread):
 
     def __init__(
         self,

--- a/src/realtime_pipeline/realtime_pipeline.py
+++ b/src/realtime_pipeline/realtime_pipeline.py
@@ -1,6 +1,6 @@
 from bisect import bisect_left
 import threading
-from typing import Callable, override
+from typing import Callable, Optional, Dict, List, Tuple
 
 from sortedcontainers import SortedDict
 from readerwriterlock import rwlock
@@ -9,10 +9,11 @@ Timestamp = float
 
 
 class Node[Data](threading.Thread):
+
     def __init__(
         self,
         acceptable_time_bias=1.5,
-        target: Callable | None = None,
+        target: Optional[Callable] = None,
     ) -> None:
         super().__init__()
         self.acceptable_time_bias = acceptable_time_bias
@@ -22,9 +23,9 @@ class Node[Data](threading.Thread):
         """ Timestamp -> Data """
 
         self._data_lock = rwlock.RWLockFair()
-        self._last_downstream_gots: dict[Node, Timestamp] = {}
+        self._last_downstream_gots: Dict[Node, Timestamp] = {}
         self._subscribe_lock = threading.Lock()
-        self._upstreams: list[Node] = []
+        self._upstreams: List[Node] = []
         self._new_data_available = threading.Event()
 
     def subscribe(self, subscriber: "Node"):
@@ -43,7 +44,7 @@ class Node[Data](threading.Thread):
             self._last_downstream_gots.pop(subscriber)
             subscriber._upstreams.remove(self)
 
-    def _query_availables(self, downstream: "Node", block=True) -> list[Timestamp]:
+    def _query_availables(self, downstream: "Node", block=True) -> List[Timestamp]:
         """Tries to query available data timestamps for the downstream node.
         If `block` is True, it will return with currently available timestamps or block until one is available.
         If `block` is False, it will return immediately with available timestamps or an empty list.
@@ -56,7 +57,7 @@ class Node[Data](threading.Thread):
             read_lock.release()
             self._new_data_available.wait()
             return self._query_availables(downstream)
-        availables: list[Timestamp] = list(self._data.islice(start_index, None))
+        availables: List[Timestamp] = list(self._data.islice(start_index, None))
         read_lock.release()
         return availables
 
@@ -66,7 +67,7 @@ class Node[Data](threading.Thread):
         self._last_downstream_gots[subscriber] = timestamp
         return data
 
-    def _get_from_upstream(self) -> tuple[list, Timestamp]:
+    def _get_from_upstream(self) -> Tuple[List, Timestamp]:
         # The timestamps of processed data available from upstream nodes
         while True:
             availables = [up._query_availables(self) for up in self._upstreams]
@@ -108,7 +109,6 @@ class Node[Data](threading.Thread):
                 self._data.popitem(0)
 
     # Retrieve data from upstream, process it, and clean up outdated data
-    @override
     def run(self):
         if not callable(self.target):
             raise ValueError(

--- a/uv.lock
+++ b/uv.lock
@@ -1,13 +1,20 @@
 version = 1
 revision = 2
-requires-python = ">=3.10"
+requires-python = ">=3.7"
+resolution-markers = [
+    "python_full_version >= '3.9'",
+    "python_full_version == '3.8.*'",
+    "python_full_version < '3.8'",
+]
 
 [[package]]
 name = "readerwriterlock"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
+    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
+    { name = "typing-extensions", version = "4.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a4/b9/6b7c390440ec23bf5fdf33e76d6c3b697a788b983c11cb2739d6541835d6/readerwriterlock-1.0.9.tar.gz", hash = "sha256:b7c4cc003435d7a8ff15b312b0a62a88d9800ba6164af88991f87f8b748f9bea", size = 16595, upload-time = "2021-09-06T03:41:21.75Z" }
 wheels = [
@@ -23,11 +30,19 @@ dependencies = [
     { name = "sortedcontainers" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "vermin" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "readerwriterlock", specifier = ">=1.0.9" },
     { name = "sortedcontainers", specifier = ">=2.4.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "vermin", specifier = ">=1.6.0" }]
 
 [[package]]
 name = "sortedcontainers"
@@ -40,10 +55,45 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
+version = "4.7.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.8'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/8b/0111dd7d6c1478bf83baa1cab85c686426c7a6274119aceb2bd9d35395ad/typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2", size = 72876, upload-time = "2023-07-02T14:20:55.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/6b/63cc3df74987c36fe26157ee12e09e8f9db4de771e0f3404263117e75b95/typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36", size = 33232, upload-time = "2023-07-02T14:20:53.275Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.13.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.8.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
+]
+
+[[package]]
+name = "typing-extensions"
 version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.9'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
 ]
 
+[[package]]
+name = "vermin"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/26/7b871396c33006c445c25ef7da605ecbd6cef830d577b496d2b73a554f9d/vermin-1.6.0.tar.gz", hash = "sha256:6266ca02f55d1c2aa189a610017c132eb2d1934f09e72a955b1eb3820ee6d4ef", size = 93181, upload-time = "2023-11-25T20:58:25.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/98/1a2ca43e6d646421eea16ec19977e2e6d1ea9079bd9d873bfae513d43f1c/vermin-1.6.0-py2.py3-none-any.whl", hash = "sha256:f1fa9ee40f59983dc40e0477eb2b1fa8061a3df4c3b2bcf349add462a5610efb", size = 90845, upload-time = "2023-11-25T20:58:22.69Z" },
+]


### PR DESCRIPTION
- Enhance compatibility by supporting Python versions as low as 3.7
- Updating the CI configuration to run tests across multiple Python versions. 