### PR TITLE
Update uv.lock when dependabot updates requirements.txt

### DIFF
--- a/.github/workflows/update_uv.lock.yml
+++ b/.github/workflows/update_uv.lock.yml
@@ -1,0 +1,58 @@
+name: Update uv.lock if dependabot update requirements.txt only
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: ["dependabot/uv/*"]
+    paths:
+      - "requirements.txt"
+
+jobs:
+  update_uv_lock:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.3"
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+
+      - name: Extract package and versions from PR title
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          # PR title format: chore(deps): bump <package> from <prev_version> to <version>
+          PACKAGE=$(echo "$PR_TITLE" | sed -n 's/.*bump \([^ ]*\) from .*/\1/p')
+          PREV_VERSION=$(echo "$PR_TITLE" | sed -n 's/.* from \([^ ]*\) to .*/\1/p')
+          VERSION=$(echo "$PR_TITLE" | sed -n 's/.* to \([^ ]*\)$/\1/p')
+          echo "PACKAGE=$PACKAGE" >> $GITHUB_ENV
+          echo "PREV_VERSION=$PREV_VERSION" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Update package with uv
+        run: |
+          echo updating $PACKAGE to $VERSION
+          uv lock --upgrade-package "$PACKAGE==$VERSION"
+
+      - name: Check if uv.lock has changes
+        id: req_changed
+        run: |
+          if [ -n "$(git status --porcelain uv.lock)" ]; then
+            echo "changed=1" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push changes
+        if: steps.req_changed.outputs.changed == '1'
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git pull --ff-only
+          git add uv.lock
+          git commit -m "chore(deps): update uv.lock for $PACKAGE $PREV_VERSION -> $VERSION"
+          git push


### PR DESCRIPTION
### Problem

- Dependabot may forget to update the `uv.lock` file and only `requirements.txt` is modified.

### Solution

- Implement a GitHub Action that triggers on pull requests from dependabot.

- The action checks if `requirements.txt` has been updated and updates `uv.lock` accordingly.

- It extracts package details from the pull request title to perform the update.

### Verification

- Create a pull request with changes to `requirements.txt` by dependabot.

- Confirm that the `uv.lock` file is updated automatically and pushed back to the repository.