### PR TITLE
Improve CI workflow for updating uv.lock

### DIFF
--- a/.github/workflows/update_uv.lock.yml
+++ b/.github/workflows/update_uv.lock.yml
@@ -10,6 +10,8 @@ jobs:
   update_uv_lock:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.ref_type == 'branch' && startsWith(github.head_ref, 'dependabot/uv/')
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/update_uv.lock.yml
+++ b/.github/workflows/update_uv.lock.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/update_uv.lock.yml
+++ b/.github/workflows/update_uv.lock.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "requirements.txt"
 
+concurrency:
+  group: update-requirements-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update_uv_lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Problem

- The CI workflow previously checked out code in a detached head state, which could lead to issues when pushing.

- The workflow did not allow writes to the repository, preventing updates to the `uv.lock` file.

- In-progress workflow runs were not canceled when a new run was triggered for the same branch, leading to unnecessary resource usage.

### Solution

- Checkout code to the appropriate branch instead of a detached head.

- Allow write permissions to the repository to enable updates to the `uv.lock` file.

- Implement concurrency settings to cancel in-progress workflow runs for the same branch.

### Verification

- Test the CI workflow by triggering updates through pull requests from `dependabot` and ensure that the `uv.lock` file updates correctly.

- Confirm that only one workflow runs at a time for the same branch.